### PR TITLE
fix: dockerfile ws / node_modules permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM node:14-alpine
 ENV HOST '0.0.0.0'
 EXPOSE ${PORT:-80}
 
+USER node
+
 WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 RUN npm ci --production && npm run nuxt:build
 
-USER node
 CMD ["node", "server/express.js"]
+


### PR DESCRIPTION
Running the container before the fix was applied leads to a weird error
related to file permissions:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/5144985/152054821-4eda4d36-b7b8-4fc4-83ac-ed4c94489a4e.png">


Moving the USER directive in the dockerfile above the workspace creation
will create it as the new user; also running npm ci & nuxt:build will
make the generated files owned by the new node user, making running the
container possible without the error.

BTW: fun website 😄 