### PR TITLE
fix (tests): confirm deployment now checks /health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3102,6 +3102,26 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
+        }
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -4806,6 +4826,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+    },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true
     },
     "de-indent": {
       "version": "1.0.2",
@@ -7968,6 +7994,12 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.12.9.tgz",
       "integrity": "sha512-TdcJywkQtcwLxogc4rSMAi479G2eDPzfW0fLySks7TPhgZZ4s/tM6stnzayIh3gS/db3zExWJyUx4cNWrwAmoQ=="
     },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8103,6 +8135,12 @@
       "requires": {
         "launch-editor": "^2.2.1"
       }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -8880,6 +8918,12 @@
           }
         }
       }
+    },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -9873,6 +9917,41 @@
         "sonic-boom": "^1.0.2"
       }
     },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "pino-http": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.8.0.tgz",
@@ -9887,6 +9966,54 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
           "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+        }
+      }
+    },
+    "pino-pretty": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.5.1.tgz",
+      "integrity": "sha512-xEOUJiokdBGcZ9d0v7OY6SqEp+rrVH2drE3bHOUsK8elw44eh9V83InZqeL1dFwgD1IDnd6crUoec3hIXxfdBQ==",
+      "dev": true,
+      "requires": {
+        "args": "^5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "sonic-boom": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+          "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
         }
       }
     },
@@ -11629,6 +11756,12 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -11758,6 +11891,12 @@
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
       }
+    },
+    "secure-json-parse": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz",
+      "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==",
+      "dev": true
     },
     "selenium-webdriver": {
       "version": "4.0.0",
@@ -12262,6 +12401,12 @@
           }
         }
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "nuxt:start": "nuxt start",
     "express": "node server/express.js",
     "express:dev": "nodemon -w server --exec 'APP_BUILD_SHA=abc123 node server/express.js | pino-pretty --ignore req.headers,res.headers'",
-    "express:prod-test": "nodemon -w server --exec 'APP_BUILD_SHA=b442611 NODE_ENV=production node server/express.js | pino-pretty --ignore req.headers,res.headers'",
+    "express:prod-test": "nodemon -w server --exec 'APP_BUILD_SHA=b442611-test NODE_ENV=production node server/express.js | pino-pretty --ignore req.headers,res.headers'",
     "jasmine": "JASMINE_CONFIG_PATH=tests/jasmine.config.json jasmine",
     "lint": "eslint .",
     "lint:dev": "nodemon -w component -w pages -w store --exec \"eslint .\"",
@@ -45,6 +45,7 @@
     "eslint-plugin-vue": "^7.17.0",
     "jasmine": "^3.10.0",
     "nodemon": "^2.0.13",
+    "pino-pretty": "^7.5.1",
     "selenium-webdriver": "=4.0.0"
   },
   "engines": {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -6,7 +6,7 @@ require('chromedriver')
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20 * 1000
 
 const testUrl = process.env.SELENIUM_TARGET_URL || 'http://localhost:3000/'
-const buildNo = process.env.APP_BUILD_SHA || '(Local Development)'
+const buildNo = process.env.APP_BUILD_SHA || 'b442611-test' // hash defined in package.json
 
 describe(`Deployment to ${testUrl}`, () => {
 	let driver
@@ -15,11 +15,22 @@ describe(`Deployment to ${testUrl}`, () => {
 	// -------------
 	// Note: in build agents, the browsers must run headlessly
 	// for security reasons. For details, see:
-	// https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
+	// https://stackoverflow.com/q/50642308/6906366
+	//
+	// Why No-Sandbox?
+	// ---------------
+	// For security reasons chrome is unable to provide sandboxing
+	// when it is running in container-based environments, see:
+	// https://stackoverflow.com/a/59154049/6906366
+	// This seems to also apply for running in WSL1
 	beforeAll(async () => {
+		const options = new chrome.Options().addArguments(
+			'--headless',
+			'--no-sandbox'
+		)
 		driver = await new Builder()
 			.forBrowser('chrome')
-			.setChromeOptions(new chrome.Options().headless())
+			.setChromeOptions(options)
 			.build()
 	})
 
@@ -31,16 +42,14 @@ describe(`Deployment to ${testUrl}`, () => {
 	}, 15000)
 
 	it('has correct Build #', async () => {
-		let versionNo
-		await driver.get(testUrl)
+		// prevent double slashes at end of url
+		const healthEndpoint = testUrl.replace(/\/$/, '') + '/health'
 
-		if (testUrl.startsWith('http://localhost')) {
-			versionNo = await driver.findElement(By.css('#js-build-no')).getText()
-		} else {
-			const el = await driver.findElement(By.css('#js-build-no')).getAttribute('href')
-			const url = el.split('/')
-			versionNo = url[url.length - 1]
-		}
-		expect(versionNo).toEqual(buildNo)
+		await driver.get(healthEndpoint)
+
+		const content = await driver.findElement(By.css('pre')).getText()
+		const healtData = JSON.parse(content)
+
+		expect(healtData.details.env.APP_BUILD_SHA).toEqual(buildNo)
 	})
 })


### PR DESCRIPTION
I guess this could fix the failing `cd` pipeline

__Things that changed:__
- updated deployment.test.js to check /health endpoint instaed of a
version in footer (removed there in 6dbd67d2)
- changed expected buildNo for local dev / testing to APP_BUILD_SHA
defined in express:prod-test script and added `-test` suffix for clarity
that this is an arbitrary hash
- added `--no-sandbox` option to for chromedriver, so that test can be
run in a container based environment
- added pino-pretty to devDependencies, this is expected by script
express:prod-test

__Things I'm uncertain about:__
- In line 51-52 in `deployment.test.js`: Is this 'the' proper way to check the json response?